### PR TITLE
`asdf` version manager bestand

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+nodejs lts-gallium


### PR DESCRIPTION
dit bestand wordt gebruikt door asdf (een version manager voor onder andere nodejs) om aan te geven dat het project gebruik maakt van nodejs 16 aka lts-gallium